### PR TITLE
Fix best length while searching for a valid rule.

### DIFF
--- a/pathparser.js
+++ b/pathparser.js
@@ -34,7 +34,8 @@
             var missingParams = {};
             
             // Parse path components
-            for (var i = 0; i < rule.parts.length; i++) {
+            var length = pathParts.length>rule.parts.length?pathParts.length:rule.parts.length;
+            for (var i = 0; i < length; i++) {
                 var rulePart = rule.parts[i];
                 var part = pathParts[i];
                 


### PR DESCRIPTION
I notice that fixed rules do not work as expected.
If I define blog and blog/users the router found blog first, even If my hash is blog/users.

So I change a line for looping depending the high length in parts. pathParts or ruleParts.
