### PR TITLE
Fix best length while searching for a valid rule. #2

### DIFF
--- a/pathparser.js
+++ b/pathparser.js
@@ -33,10 +33,15 @@
             var params = {};
             var missingParams = {};
             
+            
+            
             // Parse path components
             for (var i = 0; i < rule.parts.length; i++) {
                 var rulePart = rule.parts[i];
                 var part = pathParts[i];
+                
+                if (rulePart == undefined) return false; 
+                if (part == undefined) return false; 
                 
                 if (part !== undefined) {
                     // Assign part to named parameter


### PR DESCRIPTION
To avoid incorrect matches I forgot to add these two lines y added to my code. 
Searching for the highest length first will bring to you undefined on a rulePart or pathPart, depends if you run 
a more specific path under a less one or the opposite.
I dont know if I am clear.
